### PR TITLE
Driver link payment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.fontFamily": "MesloLGS NF",
+    "terminal.integrated.fontFamily": "MesloLGS NF, Menlo, Monaco, 'Courier New', monospace"
+}

--- a/common/payment_paid_sync.py
+++ b/common/payment_paid_sync.py
@@ -49,8 +49,10 @@ def sync_job_is_paid_from_payments(job_id: int) -> None:
     target = job.job_price_in_euros
     if target is None:
         return
-    total = sum_complete_payments_eur(job.payments)
-    should_pay = payments_meet_target_eur(total, target)
+    complete_payments = _complete_payments_base_qs(job.payments.all())
+    has_recorded_payment = complete_payments.exists()
+    total = complete_payments.aggregate(s=Sum('payment_amount_in_euros'))['s'] or Decimal('0')
+    should_pay = has_recorded_payment and payments_meet_target_eur(total, target)
     if job.is_paid != should_pay:
         Job.objects.filter(pk=job_id).update(is_paid=should_pay)
 
@@ -60,8 +62,10 @@ def sync_shuttle_is_paid_from_payments(shuttle_id: int) -> None:
 
     shuttle = Shuttle.objects.get(pk=shuttle_id)
     target = shuttle.price
-    total = sum_complete_payments_eur(shuttle.payments)
-    should_pay = payments_meet_target_eur(total, target)
+    complete_payments = _complete_payments_base_qs(shuttle.payments.all())
+    has_recorded_payment = complete_payments.exists()
+    total = complete_payments.aggregate(s=Sum('payment_amount_in_euros'))['s'] or Decimal('0')
+    should_pay = has_recorded_payment and payments_meet_target_eur(total, target)
     if shuttle.is_paid != should_pay:
         Shuttle.objects.filter(pk=shuttle_id).update(is_paid=should_pay)
 
@@ -73,8 +77,10 @@ def sync_hotel_is_paid_from_payments(booking_id: int) -> None:
     target = guest.customer_pays_in_euros
     if target is None:
         return
-    total = sum_complete_payments_eur(guest.payments)
-    should_pay = payments_meet_target_eur(total, target)
+    complete_payments = _complete_payments_base_qs(guest.payments.all())
+    has_recorded_payment = complete_payments.exists()
+    total = complete_payments.aggregate(s=Sum('payment_amount_in_euros'))['s'] or Decimal('0')
+    should_pay = has_recorded_payment and payments_meet_target_eur(total, target)
     if guest.is_paid != should_pay:
         HotelBooking.objects.filter(pk=booking_id).update(is_paid=should_pay)
 

--- a/common/test_payment_paid_sync.py
+++ b/common/test_payment_paid_sync.py
@@ -121,6 +121,49 @@ class AutoIsPaidJobTests(TestCase):
         self.assertFalse(job.is_paid)
 
     @patch('jobs.models.get_exchange_rate', return_value=Decimal('1'))
+    def test_zero_price_job_not_paid_without_recorded_payment(self, _mock_rate):
+        job = Job.objects.create(
+            customer_name='C',
+            customer_number='1',
+            job_date=timezone.now().date(),
+            job_time=timezone.now().time(),
+            job_price=Decimal('0.00'),
+            job_currency='EUR',
+            payment_type='Cash',
+            pick_up_location='X',
+            no_of_passengers=1,
+            vehicle_type='Car',
+            driver=self.driver,
+        )
+        job.refresh_from_db()
+        self.assertFalse(job.is_paid)
+
+    @patch('jobs.models.get_exchange_rate', return_value=Decimal('1'))
+    def test_zero_price_job_paid_with_nonzero_recorded_payment(self, _mock_rate):
+        job = Job.objects.create(
+            customer_name='C',
+            customer_number='1',
+            job_date=timezone.now().date(),
+            job_time=timezone.now().time(),
+            job_price=Decimal('0.00'),
+            job_currency='EUR',
+            payment_type='Cash',
+            pick_up_location='X',
+            no_of_passengers=1,
+            vehicle_type='Car',
+            driver=self.driver,
+        )
+        Payment.objects.create(
+            job=job,
+            payment_amount=Decimal('1.00'),
+            payment_currency='EUR',
+            payment_type='Cash',
+            paid_to_driver=self.driver,
+        )
+        job.refresh_from_db()
+        self.assertTrue(job.is_paid)
+
+    @patch('jobs.models.get_exchange_rate', return_value=Decimal('1'))
     def test_job_unpaid_when_payment_deleted_below_threshold(self, _mock_rate):
         job = Job.objects.create(
             customer_name='C',
@@ -264,6 +307,19 @@ class AutoIsPaidShuttleTests(TestCase):
         self.shuttle.refresh_from_db()
         self.assertTrue(self.shuttle.is_paid)
 
+    def test_zero_price_shuttle_not_paid_without_recorded_payment(self):
+        zero_shuttle = Shuttle.objects.create(
+            customer_name='SZ',
+            customer_number='2',
+            shuttle_date=timezone.now().astimezone(self.bt).date(),
+            shuttle_direction='buda_keres',
+            no_of_passengers=2,
+            driver=self.driver,
+            price=Decimal('0.00'),
+        )
+        zero_shuttle.refresh_from_db()
+        self.assertFalse(zero_shuttle.is_paid)
+
 
 class AutoIsPaidHotelTests(TestCase):
     @patch('hotels.models.get_exchange_rate', return_value=Decimal('1'))
@@ -336,5 +392,30 @@ class AutoIsPaidHotelTests(TestCase):
         self.assertTrue(booking.is_paid)
         booking.customer_pays = Decimal('200.00')
         booking.save()
+        booking.refresh_from_db()
+        self.assertFalse(booking.is_paid)
+
+    @patch('hotels.models.get_exchange_rate', return_value=Decimal('1'))
+    def test_zero_customer_pays_hotel_not_paid_without_recorded_payment(self, _mock):
+        agent = Agent.objects.create(name='HC')
+        t0 = timezone.now()
+        booking = HotelBooking.objects.create(
+            customer_name='Guest3',
+            customer_number='3',
+            check_in=t0 + timezone.timedelta(days=1),
+            check_out=t0 + timezone.timedelta(days=2),
+            no_of_people=1,
+            hotel_name='Hilton',
+            rooms=1,
+            no_of_beds=1,
+            hotel_tier=3,
+            hotel_price=Decimal('200.00'),
+            hotel_price_currency='EUR',
+            customer_pays=Decimal('0.00'),
+            customer_pays_currency='EUR',
+            agent=agent,
+            agent_percentage='10%',
+            payment_type='Cash',
+        )
         booking.refresh_from_db()
         self.assertFalse(booking.is_paid)

--- a/hotels/views.py
+++ b/hotels/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render, redirect, get_object_or_404
+from decimal import Decimal
 from hotels.forms import HotelBookingForm
 from django.urls import reverse
 from hotels.models import HotelBooking, HotelBookingBedType, BedType
@@ -14,6 +15,7 @@ from django.forms import modelformset_factory
 import logging
 import pytz
 from django.core.exceptions import ValidationError
+from common.payment_paid_sync import sum_complete_payments_eur
 logger = logging.getLogger('kt')
 
 # Set the timezone to Hungary
@@ -348,7 +350,14 @@ def client_view_guest(request, public_id):
     except HotelBooking.DoesNotExist:
         return render(request, "errors/404.html", status=404)
 
-    return render(request, 'hotels/client_view_guest.html', {'guest': guest})
+    recorded_payments_eur = sum_complete_payments_eur(guest.payments)
+    payment_balance = max((guest.customer_pays_in_euros or Decimal('0.00')) - recorded_payments_eur, Decimal('0.00'))
+    has_recorded_payments = recorded_payments_eur > Decimal('0.00')
+    return render(request, 'hotels/client_view_guest.html', {
+        'guest': guest,
+        'payment_balance': payment_balance,
+        'has_recorded_payments': has_recorded_payments,
+    })
 
 
 def client_view_guest_tefilas_rabim(request, public_id):

--- a/jobs/migrations/0050_job_show_payment_on_driver_link.py
+++ b/jobs/migrations/0050_job_show_payment_on_driver_link.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('jobs', '0049_backfill_job_subtotal_where_null'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='job',
+            name='show_payment_on_link',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/jobs/migrations/0051_repair_show_payment_on_link_column.py
+++ b/jobs/migrations/0051_repair_show_payment_on_link_column.py
@@ -1,0 +1,47 @@
+from django.db import migrations
+
+
+def repair_show_payment_on_link_column(apps, schema_editor):
+    """
+    Repair local DBs that may have diverged while renaming the field:
+    - If old column exists and new doesn't, rename old -> new.
+    - If neither exists, add new with default true.
+    - If new already exists, no-op.
+    """
+    connection = schema_editor.connection
+    table_name = "jobs_job"
+    old_col = "show_payment_on_driver_link"
+    new_col = "show_payment_on_link"
+
+    with connection.cursor() as cursor:
+        columns = {
+            row.name
+            for row in connection.introspection.get_table_description(cursor, table_name)
+        }
+
+        if new_col in columns:
+            return
+
+        if old_col in columns:
+            cursor.execute(
+                f"ALTER TABLE {table_name} RENAME COLUMN {old_col} TO {new_col}"
+            )
+            return
+
+        cursor.execute(
+            f"ALTER TABLE {table_name} ADD COLUMN {new_col} bool NOT NULL DEFAULT 1"
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("jobs", "0050_job_show_payment_on_driver_link"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            repair_show_payment_on_link_column,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/jobs/migrations/0052_alter_job_show_payment_on_link_default.py
+++ b/jobs/migrations/0052_alter_job_show_payment_on_link_default.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("jobs", "0051_repair_show_payment_on_link_column"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="job",
+            name="show_payment_on_link",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/jobs/migrations/0053_backfill_show_payment_on_link_hidden.py
+++ b/jobs/migrations/0053_backfill_show_payment_on_link_hidden.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def set_driver_link_payment_hidden(apps, schema_editor):
+    Job = apps.get_model("jobs", "Job")
+    Job.objects.all().update(show_payment_on_link=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("jobs", "0052_alter_job_show_payment_on_link_default"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            set_driver_link_payment_hidden,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/jobs/migrations/0054_resync_job_is_paid_safely.py
+++ b/jobs/migrations/0054_resync_job_is_paid_safely.py
@@ -1,0 +1,52 @@
+from decimal import Decimal
+
+from django.db import migrations
+from django.db.models import Sum
+
+
+PAID_AMOUNT_TOLERANCE_EUR = Decimal("5.00")
+
+
+def _complete_payments_qs(Payment, job_id):
+    return Payment.objects.filter(
+        job_id=job_id,
+        payment_amount__isnull=False,
+        payment_currency__isnull=False,
+        payment_type__isnull=False,
+        payment_amount_in_euros__isnull=False,
+    ).exclude(
+        paid_to_driver=None,
+        paid_to_agent=None,
+        paid_to_staff=None,
+    )
+
+
+def resync_job_is_paid_safely(apps, schema_editor):
+    Job = apps.get_model("jobs", "Job")
+    Payment = apps.get_model("common", "Payment")
+
+    for job in Job.objects.all().only("id", "is_paid", "job_price_in_euros").iterator():
+        target = job.job_price_in_euros
+        if target is None:
+            continue
+
+        complete_qs = _complete_payments_qs(Payment, job.id)
+        has_recorded_payment = complete_qs.exists()
+        total = complete_qs.aggregate(s=Sum("payment_amount_in_euros"))["s"] or Decimal("0")
+        threshold = target - PAID_AMOUNT_TOLERANCE_EUR
+        should_pay = has_recorded_payment and total >= threshold
+
+        if job.is_paid != should_pay:
+            Job.objects.filter(pk=job.id).update(is_paid=should_pay)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("jobs", "0053_backfill_show_payment_on_link_hidden"),
+        ("common", "0015_backfill_is_paid_from_payments"),
+    ]
+
+    operations = [
+        migrations.RunPython(resync_job_is_paid_safely, migrations.RunPython.noop),
+    ]

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -75,6 +75,7 @@ class Job(models.Model):
     is_confirmed = models.BooleanField(default=False)
     is_completed = models.BooleanField(default=False)
     is_paid = models.BooleanField(default=False)
+    show_payment_on_link = models.BooleanField(default=False)
     payment_type = models.CharField(max_length=10, choices=PAYMENT_TYPE_CHOICES, null=True, blank=True)
 
     # Exchange Rate for Currency Conversion

--- a/jobs/urls.py
+++ b/jobs/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('view/<int:job_id>/', views.view_job, name='view_job'),  
     path('delete/<int:job_id>/', views.delete_job, name='delete_job'), 
     path('jobs/update_status/<int:job_id>/', views.update_job_status, name='update_job_status'),
+    path('jobs/toggle_show_payment_on_link/<int:job_id>/', views.toggle_show_payment_on_link, name='toggle_show_payment_on_link'),
     path('job/<str:lookup>/details/', views.client_job_view, name='client_job_view'),
     path('job/<str:public_id>/driver-details/', views.client_view_job_driver, name='view_job_driver'),
 ]

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -19,7 +19,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseForbidden
 from decimal import Decimal
 import logging
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpResponse, JsonResponse
 import pytz
 from common.utils import (
     assign_job_color,
@@ -27,6 +27,7 @@ from common.utils import (
     form_and_formset_error_summary,
     get_home_exchange_rate_banner_context,
 )
+from common.payment_paid_sync import sum_complete_payments_eur
 import datetime
 from django.utils.html import escape
 from operator import attrgetter
@@ -601,6 +602,19 @@ def update_job_status(request, job_id):
     return render(request, 'jobs/view_job.html', {'job': job, 'error_message': error_message}, status=400)
 
 
+@login_required
+@require_POST
+def toggle_show_payment_on_link(request, job_id):
+    job = get_object_or_404(Job, pk=job_id)
+    show_payment_on_link = request.POST.get('show_payment_on_link') == 'true'
+    job.show_payment_on_link = show_payment_on_link
+    job.save(update_fields=['show_payment_on_link'])
+    return JsonResponse({
+        'ok': True,
+        'show_payment_on_link': job.show_payment_on_link,
+    })
+
+
 def client_job_view(request, lookup):
     # Only allow access via public_id — block numeric IDs
     if lookup.isdigit():
@@ -611,7 +625,15 @@ def client_job_view(request, lookup):
     except Job.DoesNotExist:
         return render(request, "errors/404.html", status=404)
 
-    return render(request, 'jobs/client_view_job.html', {'job': job})
+    recorded_payments_eur = sum_complete_payments_eur(job.payments)
+    payment_balance = max((job.job_price_in_euros or Decimal('0.00')) - recorded_payments_eur, Decimal('0.00'))
+    has_recorded_payments = recorded_payments_eur > Decimal('0.00')
+
+    return render(request, 'jobs/client_view_job.html', {
+        'job': job,
+        'payment_balance': payment_balance,
+        'has_recorded_payments': has_recorded_payments,
+    })
 
 
 def client_view_job_driver(request, public_id):
@@ -624,4 +646,12 @@ def client_view_job_driver(request, public_id):
     except Job.DoesNotExist:
         return render(request, "errors/404.html", status=404)
 
-    return render(request, 'jobs/client_view_job_driver.html', {'job': job})
+    recorded_payments_eur = sum_complete_payments_eur(job.payments)
+    payment_balance = max((job.job_price_in_euros or Decimal('0.00')) - recorded_payments_eur, Decimal('0.00'))
+    has_recorded_payments = recorded_payments_eur > Decimal('0.00')
+
+    return render(request, 'jobs/client_view_job_driver.html', {
+        'job': job,
+        'payment_balance': payment_balance,
+        'has_recorded_payments': has_recorded_payments,
+    })

--- a/shuttle/views.py
+++ b/shuttle/views.py
@@ -1,5 +1,6 @@
 from shuttle.models import Shuttle, ShuttleDay, ShuttleDailyCost
 from shuttle.forms import ShuttleForm, DriverAssignmentForm, ShuttleDailyCostForm
+from decimal import Decimal
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import Http404
 from django.views.decorators.http import require_POST
@@ -24,6 +25,7 @@ import pytz
 import logging
 import re
 from common.utils import scramble_date, now_budapest
+from common.payment_paid_sync import sum_complete_payments_eur
 logger = logging.getLogger('kt')
 
 
@@ -458,7 +460,14 @@ def client_view_shuttle(request, lookup):
     shuttle = Shuttle.objects.filter(public_id=lookup).first()
     if not shuttle:
         return render(request, 'errors/404.html', status=404)
-    return render(request, 'shuttle/client_view_shuttle.html', {'shuttle': shuttle})
+    recorded_payments_eur = sum_complete_payments_eur(shuttle.payments)
+    payment_balance = max((shuttle.price or Decimal('0.00')) - recorded_payments_eur, Decimal('0.00'))
+    has_recorded_payments = recorded_payments_eur > Decimal('0.00')
+    return render(request, 'shuttle/client_view_shuttle.html', {
+        'shuttle': shuttle,
+        'payment_balance': payment_balance,
+        'has_recorded_payments': has_recorded_payments,
+    })
 
 
 def shuttle_summary_view(request, scrambled):
@@ -482,6 +491,11 @@ def shuttle_summary_view(request, scrambled):
     total_price = sum(s.price or 0 for s in shuttles)
     total_drivers = driver_costs.values('driver').distinct().count()
     total_costs = sum(cost.driver_fee_in_euros or 0 for cost in driver_costs)
+
+    for shuttle in shuttles:
+        recorded_payments_eur = sum_complete_payments_eur(shuttle.payments)
+        shuttle.payment_balance = max((shuttle.price or Decimal('0.00')) - recorded_payments_eur, Decimal('0.00'))
+        shuttle.has_recorded_payments = recorded_payments_eur > Decimal('0.00')
 
     context = {
         'date': target_date,

--- a/static/styles.css
+++ b/static/styles.css
@@ -1155,6 +1155,61 @@ input[type="checkbox"][name$="-DELETE"] {
     display: none;
 }
 
+.driver-payment-toggle-row {
+    margin-top: 10px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.switch-toggle {
+    position: relative;
+    display: inline-block;
+    width: 46px;
+    height: 24px;
+}
+
+.switch-toggle input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.switch-toggle .slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background-color: #c9c9c9;
+    transition: 0.2s;
+    border-radius: 999px;
+}
+
+.switch-toggle .slider::before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    top: 3px;
+    background-color: #fff;
+    transition: 0.2s;
+    border-radius: 50%;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+.switch-toggle input:checked + .slider {
+    background-color: #4caf50;
+}
+
+.switch-toggle input:checked + .slider::before {
+    transform: translateX(22px);
+}
+
+.toggle-state-label {
+    min-width: 56px;
+    font-weight: 600;
+}
+
 /* Pagination controls */
 /* Expenses list: active filter chips */
 .expense-filter-tags {

--- a/templates/hotels/client_view_guest.html
+++ b/templates/hotels/client_view_guest.html
@@ -138,6 +138,8 @@
                 <div class="card"><strong>Payment:</strong> 
                     {% if guest.is_paid %}
                         ✅ Paid
+                    {% elif has_recorded_payments %}
+                        Balance: €{{ payment_balance|floatformat:2|intcomma }}
                     {% else %}
                         ❌ Not Paid
                     {% endif %}

--- a/templates/jobs/client_view_job.html
+++ b/templates/jobs/client_view_job.html
@@ -130,6 +130,8 @@
                 <div class="card"><strong>Payment:</strong> 
                     {% if job.is_paid %}
                         ✅ Paid
+                    {% elif has_recorded_payments %}
+                        Balance: €{{ payment_balance|floatformat:2|intcomma }}
                     {% else %}
                         ❌ Not Paid
                     {% endif %}

--- a/templates/jobs/client_view_job_driver.html
+++ b/templates/jobs/client_view_job_driver.html
@@ -96,11 +96,11 @@
             </div>
             {% endif %}
 
-            {% if job.job_price_in_euros %}
-            <div class="timeline-step">
-                <div class="dot"></div>
-                <div class="card"><strong>Job Price:</strong> €{{ job.job_price_in_euros|intcomma }}</div>
-            </div>
+            {% if job.show_payment_on_link and job.job_price_in_euros %}
+                <div class="timeline-step">
+                    <div class="dot"></div>
+                    <div class="card"><strong>Job Price:</strong> €{{ job.job_price_in_euros|intcomma }}</div>
+                </div>
             {% endif %}
 
             {% if job.job_description %}
@@ -125,16 +125,20 @@
                 </div>
             </div>
 
-            <div class="timeline-step" style="--i:13;">
-                <div class="dot"></div>
-                <div class="card"><strong>Payment:</strong> 
-                    {% if job.is_paid %}
-                        ✅ Paid
-                    {% else %}
-                        ❌ Not Paid
-                    {% endif %}
+            {% if job.show_payment_on_link %}
+                <div class="timeline-step" style="--i:13;">
+                    <div class="dot"></div>
+                    <div class="card"><strong>Payment:</strong> 
+                        {% if job.is_paid %}
+                            ✅ Paid
+                        {% elif has_recorded_payments %}
+                            Balance: €{{ payment_balance|floatformat:2|intcomma }}
+                        {% else %}
+                            ❌ Not Paid
+                        {% endif %}
+                    </div>
                 </div>
-            </div>
+            {% endif %}
 
         <p class="footer">Kerestir Travel &copy; 2024</p>
     </div>

--- a/templates/jobs/view_job.html
+++ b/templates/jobs/view_job.html
@@ -152,6 +152,15 @@
         {% endfor %}
     </div>
     <br>
+    <div class="driver-payment-toggle-row">
+        <strong>Show payment on driver link:</strong>
+        <label class="switch-toggle" for="show_payment_on_link_toggle">
+            <input type="checkbox" id="show_payment_on_link_toggle" {% if job.show_payment_on_link %}checked{% endif %}>
+            <span class="slider"></span>
+        </label>
+        <span id="show-payment-toggle-label" class="toggle-state-label">{% if job.show_payment_on_link %}Shown{% else %}Hidden{% endif %}</span>
+    </div>
+    <br>
     <form method="POST" action="{% url 'jobs:update_job_status' job.id %}">
         {% csrf_token %}
 
@@ -178,10 +187,10 @@
         <p><strong>Freelancer Job:</strong> 
             <input class="sbig" type="checkbox" id="is_freelancer" name="is_freelancer" {% if job.is_freelancer %}checked{% endif %}>
         </p>
-    
-    
+
         <button type="submit" class="button">Update Status</button>
     </form>
+    
 
     <div class="button-group">
         <a href="{% url 'jobs:edit_job' job.id %}" class="button">Edit</a>
@@ -234,6 +243,57 @@
 
 {% block extra_scripts %}
 <script>
+    function getCookie(name) {
+        let cookieValue = null;
+        if (document.cookie && document.cookie !== '') {
+            const cookies = document.cookie.split(';');
+            for (let i = 0; i < cookies.length; i++) {
+                const cookie = cookies[i].trim();
+                if (cookie.substring(0, name.length + 1) === (name + '=')) {
+                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        return cookieValue;
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const toggle = document.getElementById('show_payment_on_link_toggle');
+        const label = document.getElementById('show-payment-toggle-label');
+        if (!toggle || !label) return;
+
+        toggle.addEventListener('change', function () {
+            const intendedState = toggle.checked;
+            label.textContent = intendedState ? 'Shown' : 'Hidden';
+
+            fetch("{% url 'jobs:toggle_show_payment_on_link' job.id %}", {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'X-CSRFToken': getCookie('csrftoken'),
+                },
+                body: `show_payment_on_link=${intendedState}`,
+            })
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('Failed to save toggle.');
+                }
+                return response.json();
+            })
+            .then((data) => {
+                const savedState = Boolean(data.show_payment_on_link);
+                toggle.checked = savedState;
+                label.textContent = savedState ? 'Shown' : 'Hidden';
+            })
+            .catch(() => {
+                toggle.checked = !intendedState;
+                label.textContent = toggle.checked ? 'Shown' : 'Hidden';
+                alert('Could not update payment visibility. Please try again.');
+            });
+        });
+    });
+
     // Function to copy job details in the specified order with conditional fields
     function copyJobDetails() {
         let jobDetails = `*Name:* {{ job.customer_name|default_if_none:""|escapejs }}

--- a/templates/shuttle/client_view_shuttle.html
+++ b/templates/shuttle/client_view_shuttle.html
@@ -128,6 +128,8 @@
                 <div class="card"><strong>Payment:</strong> 
                     {% if shuttle.is_paid %}
                         ✅ Paid
+                    {% elif has_recorded_payments %}
+                        Balance: €{{ payment_balance|floatformat:2|intcomma }}
                     {% else %}
                         ❌ Not Paid
                     {% endif %}

--- a/templates/shuttle/driver_link.html
+++ b/templates/shuttle/driver_link.html
@@ -46,6 +46,8 @@
                         {% endif %}
                         {% if shuttle.is_paid %}
                             <p><strong>Payment:</strong> ✅ Paid</p>
+                        {% elif shuttle.has_recorded_payments %}
+                            <p><strong>Payment:</strong> Balance: €{{ shuttle.payment_balance|floatformat:2|intcomma }}</p>
                         {% else %}
                             <p><strong>Payment:</strong> ❌ Not Paid</p>
                         {% endif %}


### PR DESCRIPTION
- Updated paid logic so jobs/shuttles/hotels are only marked paid if there is at least one complete payment record.
- Added tests for zero-price/zero-target edge cases to prevent false “paid” statuses.
- Updated client/driver-facing payment text to show:
         ✅ Paid
         ❌ Not Paid
          Balance: €... when partially paid

- Added a driver-link visibility control for jobs (show_payment_on_link) that:
1. only affects the driver link
2. now also controls visibility of Job Price on driver link
3. auto-saves instantly (no “Update Status” click needed)
4. Made default behavior hide payment from driver link for new jobs and backfilled existing jobs to hidden.

- Added safe repair/backfill migrations for the rename/default/history issues and applied them successfully.